### PR TITLE
fix troff errors in endless-sky.6

### DIFF
--- a/endless-sky.6
+++ b/endless-sky.6
@@ -81,9 +81,9 @@ prints a table of outfits and all attributes used by any outfits present.
 .IP \fB\-\-sales
 prints (to STDOUT) a list of all shipyards and outfitters and the ships and outfits they each contain.
 .RS
-.IP \fB\-\s,\ \-\-ships
+.IP \fB\-s,\ \-\-ships
 prints a list of shipyards and the ships they each contain.
-.IP \fB\-\o,\ \-\-outfits
+.IP \fB\-o,\ \-\-outfits
 pritns a list of outfitters and the outfits they each contain.
 .RE
 


### PR DESCRIPTION
**Bugfix:** This PR addresses error messages when endless-sky.6 is processed with troff

## Fix Details
The plain letters need not be escaped, since they become special control sequences for troff

## Testing Done
There are no error messages from troff after the fix